### PR TITLE
Add UI to set OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Flask web application that provides a multi-agent workforce with specialized c
    pip install -r requirements.txt
    ```
 4. Set up your environment variables in the `.env` file:
-   - Add your OpenAI API key
+   - Add your OpenAI API key **or** provide it in the web UI (see below)
    - (Optional) Add Google Custom Search API key and Custom Search Engine ID
    - (Optional) Add Bing Search API key
 
@@ -33,7 +33,8 @@ A Flask web application that provides a multi-agent workforce with specialized c
    python app.py
    ```
 2. Open your web browser and navigate to `http://127.0.0.1:5000/`
-3. Interact with the agent workforce through the chat interface
+3. Open the **API Key** dropdown in the top-right corner and paste your OpenAI Response API key. Click **Save Key**.
+4. Interact with the agent workforce through the chat interface. The key will be stored in your browser until you click **Delete Key**.
 
 ## Web Search Configuration
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import (
     Flask, render_template, request, jsonify,
-    send_from_directory, Response, stream_with_context
+    send_from_directory, Response, stream_with_context,
+    session
 )
 import os
 import json
@@ -52,14 +53,15 @@ openai_api_key = os.getenv("OPENAI_API_KEY")
 anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
 
 if not openai_api_key:
-    raise ValueError("OPENAI_API_KEY not found in .env file")
+    print("Warning: OPENAI_API_KEY not found in .env file. Provide it via the web UI.")
 
 if not anthropic_api_key:
     print("Warning: ANTHROPIC_API_KEY not found in .env file. "
           "Coding agent will fall back to OpenAI.")
 
-# Set the API key for the OpenAI client
-os.environ["OPENAI_API_KEY"] = openai_api_key
+# Set the API key for the OpenAI client if provided
+if openai_api_key:
+    os.environ["OPENAI_API_KEY"] = openai_api_key
 
 # Initialize Anthropic client if API key is available
 anthropic_client = None
@@ -76,6 +78,17 @@ DATA_DIR = Path("user_data")
 DATA_DIR.mkdir(exist_ok=True)
 SCREENSHOTS_DIR = DATA_DIR / "screenshots"
 SCREENSHOTS_DIR.mkdir(exist_ok=True)
+
+# Ensure requests use the correct API key
+@app.before_request
+def apply_openai_key():
+    """Apply API key from request header or session."""
+    header_key = request.headers.get('X-OPENAI-KEY')
+    if header_key:
+        session['openai_api_key'] = header_key
+    key = session.get('openai_api_key', openai_api_key)
+    if key:
+        os.environ['OPENAI_API_KEY'] = key
 
 # File management tools
 
@@ -579,6 +592,13 @@ def vnc_viewer():
 @app.route('/static/<path:path>')
 def serve_static(path):
     return send_from_directory('static', path)
+
+
+@app.route('/api/remove_key', methods=['POST'])
+def remove_api_key():
+    """Remove stored API key from the session."""
+    session.pop('openai_api_key', None)
+    return jsonify({'status': 'removed'})
 
 
 @app.route('/api/chat', methods=['POST'])

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -14,6 +14,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const screenshotPreview = document.getElementById('screenshot-preview') || document.createElement('img');
     const themeToggle = document.getElementById('themeToggle');
     const streamingToggle = document.getElementById('streamingToggle');
+    const apiKeyInput = document.getElementById('apiKeyInput');
+    const saveApiKeyBtn = document.getElementById('saveApiKey');
+    const removeApiKeyBtn = document.getElementById('removeApiKey');
     
     // Visual browsing elements
     const visualBrowsingCard = document.getElementById('visual-browsing-card') || document.createElement('div');
@@ -66,6 +69,25 @@ document.addEventListener('DOMContentLoaded', function() {
             themeToggle.innerHTML = '<i class="bi bi-sun-fill"></i> <span>Light Mode</span>';
         }
     }
+
+    // Load stored API key
+    const storedKey = localStorage.getItem('openai_api_key');
+    if (storedKey && apiKeyInput) {
+        apiKeyInput.value = storedKey;
+    }
+
+    saveApiKeyBtn.addEventListener('click', function() {
+        const key = apiKeyInput.value.trim();
+        if (key) {
+            localStorage.setItem('openai_api_key', key);
+        }
+    });
+
+    removeApiKeyBtn.addEventListener('click', function() {
+        localStorage.removeItem('openai_api_key');
+        fetch('/api/remove_key', { method: 'POST' });
+        apiKeyInput.value = '';
+    });
     
     // Function to add a message to the chat
     function addMessage(content, isUser, agentName = null) {
@@ -292,11 +314,15 @@ document.addEventListener('DOMContentLoaded', function() {
         
         try {
             // First, send the message to the server
+            const headers = { 'Content-Type': 'application/json' };
+            const storedKey = localStorage.getItem('openai_api_key');
+            if (storedKey) {
+                headers['X-OPENAI-KEY'] = storedKey;
+            }
+
             const postResponse = await fetch('/api/chat/stream', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                headers,
                 body: JSON.stringify({ message })
             });
             

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,16 @@
                     <input class="form-check-input me-2" type="checkbox" id="streamingToggle" checked>
                     <label class="form-check-label" for="streamingToggle">Streaming</label>
                 </div>
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="apiKeyDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                        API Key
+                    </button>
+                    <div class="dropdown-menu p-3" aria-labelledby="apiKeyDropdown" style="min-width: 250px;">
+                        <input type="password" class="form-control mb-2" id="apiKeyInput" placeholder="OpenAI API Key">
+                        <button class="btn btn-primary w-100 mb-2" type="button" id="saveApiKey">Save Key</button>
+                        <button class="btn btn-danger w-100" type="button" id="removeApiKey">Delete Key</button>
+                    </div>
+                </div>
                 <button class="btn btn-outline-secondary theme-toggle" id="themeToggle">
                     <i class="bi bi-moon-fill"></i>
                     <span>Dark Mode</span>
@@ -71,6 +81,7 @@
         </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/static/js/main.js"></script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- add API key dropdown UI with save/delete
- persist API key in browser localStorage
- include API key headers in chat requests
- store key server-side in session via before_request
- document new UI instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_6856f1abc0988327a1092050c5d6646c